### PR TITLE
refresh the epg after 5 min if there is a dummy epg

### DIFF
--- a/lib/tvheadend/epg2xml.py
+++ b/lib/tvheadend/epg2xml.py
@@ -67,6 +67,8 @@ class EPGLocast:
         with open(out_path, 'wb') as f:
             f.write(b'<?xml version="1.0" encoding="UTF-8"?>\n')
             f.write(ET.tostring(out, encoding='UTF-8'))
+        newtime = int(time.time()) - int(self.config["epg"]["min_refresh_rate"]) - 3300
+        os.utime(out_path, (newtime, newtime))
 
     def generate_epg_file(self):
 


### PR DESCRIPTION
When doing a new install with no previous cache it takes 4 to 5 hours to get the EPG populated which may lead a user to believe they did something wrong.  This update will allow the EPG to be updated after 5 minutes when an HTTP request for epg data is received.