### PR TITLE
CONFIG_DEFN_PATH update for docker plus update docker files for data dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache --update ffmpeg
 COPY *.ini /app/
 COPY *.py /app/
 COPY cache/ /app/cache/
+COPY data/ /app/data/
 COPY lib/ /app/lib/
 COPY known_stations.json /app/
 RUN touch /app/is_container

--- a/Dockerfile_l2p
+++ b/Dockerfile_l2p
@@ -4,6 +4,7 @@ LABEL maintainer="Thomas Gorgolione <thomas@tgorg.com>"
 RUN apk add --no-cache --update ffmpeg
 COPY *.py /app/
 COPY cache/ /app/cache/
+COPY data/ /app/data/
 COPY lib/ /app/lib/
 COPY known_stations.json /app/
 RUN touch /app/is_container

--- a/Dockerfile_tvh
+++ b/Dockerfile_tvh
@@ -4,6 +4,7 @@ LABEL maintainer="Thomas Gorgolione <thomas@tgorg.com>"
 RUN apk add --no-cache --update ffmpeg
 COPY *.py /app/
 COPY cache/ /app/cache/
+COPY data/ /app/data/
 COPY lib/ /app/lib/
 COPY known_stations.json /app/
 RUN touch /app/is_container

--- a/Dockerfile_tvh_crypt.alpine
+++ b/Dockerfile_tvh_crypt.alpine
@@ -7,6 +7,7 @@ RUN apk add --no-cache --update bash tzdata ffmpeg curl && \
     apk del builddeps
 COPY *.py /app/
 COPY cache/ /app/cache/
+COPY data/ /app/data/
 COPY lib/ /app/lib/
 RUN touch /app/is_container
 

--- a/Dockerfile_tvh_crypt.slim-buster
+++ b/Dockerfile_tvh_crypt.slim-buster
@@ -27,6 +27,7 @@ RUN apt-get update \
 
 COPY *.py /app/
 COPY cache/ /app/cache/
+COPY data/ /app/data/
 COPY lib/ /app/lib/
 RUN touch /app/is_container
 

--- a/lib/tvheadend/user_config.py
+++ b/lib/tvheadend/user_config.py
@@ -41,7 +41,7 @@ class TVHUserConfig(lib.user_config.UserConfig):
     def __init__(self, script_dir=None, opersystem=None, args=None, config=None):
         self.logger = None
         if TVHUserConfig.defn_json is None:
-            TVHUserConfig.defn_json = self.load_config_defn(CONFIG_DEFN_PATH)
+            TVHUserConfig.defn_json = self.load_config_defn(pathlib.Path(script_dir).joinpath(CONFIG_DEFN_PATH))
         self.config_defaults = self.init_default_config(TVHUserConfig.defn_json)
         self.data = copy.deepcopy(self.config_defaults)
         if script_dir is not None:


### PR DESCRIPTION
Updates for the new 'data' directory for Docker.  0.7.5c was causing exceptions when it could not find data/config_defn directory.

1) CONFIG_DEFN_PATH needed further qualification due to it being in /app/data/config_defn when in docker

2) docker needs to copy the new data directory into the docker container.  I updated all 5 dockerfiles but maybe some pruning of docker file files would be good in the future.  Here are the ones I have used in the last week or two.
- Dockerfile_tvh_crypt.slim-buster: Debian with Cryptography - this is the one I use
- Dockerfile_tvh_crypt.alpine: Alpine with cryptography
- Dockerfile_tvh: Alpine without cryptography - this one works but gets message saying cryptography module not loaded

These are totally untested by me anyway - not sure if these were copied from locast2plex and are legacy/unused or not.
- Dockerfile
- Dockerfile_l2p

Maybe a future update could simplify the number of dockerfiles.  I suggest having only 2 dockerfiles. one with and one without cryptography
- delete Dockerfile, Dockerfile_l2p and Dockerfile_tvh_crypt.alpine
- rename Dockerfile_tvh to Dockerfile